### PR TITLE
Issue20/Use-factories-for-fuel-subsystem-commands

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,10 +4,7 @@
 
 package frc.robot;
 
-import java.io.File;
-
 import com.pathplanner.lib.auto.AutoBuilder;
-
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.GenericHID;
@@ -25,6 +22,7 @@ import frc.robot.Constants.OIConstants;
 import frc.robot.subsystems.CANFuelSubsystem;
 import frc.robot.subsystems.LEDSubsystem;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
+import java.io.File;
 import swervelib.SwerveInputStream;
 
 /**
@@ -196,20 +194,14 @@ public class RobotContainer {
     // Define operator commands and button mappings here
 
     // While the left bumper on operator controller is held, intake Fuel
-    operatorController
-        .leftBumper()
-        .whileTrue(ballSubsystem.intakeCommand().withName("Intake"));
+    operatorController.leftBumper().whileTrue(ballSubsystem.intakeCommand().withName("Intake"));
 
     // While the right bumper on the operator controller is held, spin up for 1
     // second, then launch fuel. When the button is released, stop.
-    operatorController
-        .rightBumper()
-        .whileTrue(ballSubsystem.launchCommand().withName("Launch"));
+    operatorController.rightBumper().whileTrue(ballSubsystem.launchCommand().withName("Launch"));
     // While the A button is held on the operator controller, eject fuel back out
     // the intake
-    operatorController
-        .a()
-        .whileTrue(ballSubsystem.ejectCommand().withName("Eject"));
+    operatorController.a().whileTrue(ballSubsystem.ejectCommand().withName("Eject"));
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/CANFuelSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/CANFuelSubsystem.java
@@ -28,7 +28,6 @@ import com.revrobotics.ResetMode;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.SparkMaxConfig;
-
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.filter.SlewRateLimiter;
@@ -166,15 +165,13 @@ public class CANFuelSubsystem extends SubsystemBase {
 
   // A command factory to turn the eject method into a command that requires this
   // subsystem
-  public Command ejectCommand()
-  {
+  public Command ejectCommand() {
     return this.runEnd(this::eject, this::stop);
   }
 
   // A command factory to turn the intake method into a command that requires this
   // subsystem
-  public Command intakeCommand()
-  {
+  public Command intakeCommand() {
     return this.runEnd(this::intake, this::stop);
   }
 


### PR DESCRIPTION
Remove spin up and use command factories for all fuel subsystem commands